### PR TITLE
Escape dot metacharacter, simplify OTP regexes

### DIFF
--- a/Yubico.php
+++ b/Yubico.php
@@ -218,8 +218,8 @@ class Auth_Yubico
 			  $str, $matches)) {
 	    /* Dvorak? */
 	    if (!preg_match("/^((.*)" . $delim . ")?" .
-			    "(([jxe.uidchtnbpygk]{0,16})" .
-			    "([jxe.uidchtnbpygk]{32}))$/i",
+			    "(([jxe\.uidchtnbpygk]{0,16})" .
+			    "([jxe\.uidchtnbpygk]{32}))$/i",
 			    $str, $matches)) {
 	      return false;
 	    } else {


### PR DESCRIPTION
I've escaped the dot metacharacter in the Dvorak regex, which would match any character. Also, to simplify future regex maintenance, if any, I've made the regexes case-insensitive.
