### PR TITLE
Update README

### DIFF
--- a/README
+++ b/README
@@ -48,8 +48,7 @@ This is an example of how you can use the `Yubico.php` inside an HTML *.php file
 
 Provided in the package is also a script 
 https://github.com/Yubico/php-yubico/blob/master/demo.php[demo.php]
-that demonstrates how you may use the package. The script is deployed 
-https://demo.yubico.com/php-yubico/demo.php[here].
+that demonstrates how you may use the package.
 
 ==== Example site
 There is also a complete example site that demonstrates one-factor and
@@ -58,8 +57,6 @@ passwords.  Database schema is in
 https://github.com/Yubico/php-yubico/blob/master/example/db.sql[example/db.sql]
 and configuration for the database needs to go into
 https://github.com/Yubico/php-yubico/blob/master/example/config.php[example/config.php].
-
-The example site is deployed https://demo.yubico.com/php-yubico[here].
 
 
 === Modhex Calculator


### PR DESCRIPTION
Removing links to old demo.yubico.com pages.

Does the new OTP verify page (https://demo.yubico.com/otp/verify) use this php code?