### PR TITLE
New yubicloud has a load balancer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ php:
   - 7.3
   - 7.4
 after_success:
-  - test -z $COVERALLS || (composer require satooshi/php-coveralls && vendor/bin/coveralls -v)
+  - test -z $COVERALLS || (composer require php-coveralls/php-coveralls && vendor/bin/coveralls -v)
 matrix:
   include:
     - php: 7.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
 language: php
+os: linux
+dist: bionic
 sudo: false
 php:
-  - 5.6
-  - 7.1
   - 7.2
-  - hhvm
+  - 7.3
+  - 7.4
 after_success:
   - test -z $COVERALLS || (composer require satooshi/php-coveralls && vendor/bin/coveralls -v)
 matrix:
   include:
-    - php: 5.6
+    - php: 7.2
       env: COVERALLS=true
-  allow_failures:
-    - php: hhvm

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=2.6
+VERSION=2.7
 PACKAGE=Auth_Yubico
 CODE=COPYING NEWS README Yubico.php package.xml demo.php
 EXAMPLE=example/admin.php example/authenticate.php example/config.php	\

--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,8 @@
 * Version 2.7 released 2020-02-??
  ** Default to just api.yubico.com (now load balanced)
  ** Retry transient errors
- ** No longer support PHP 5.6 (EOL 2018-12-31)
+ ** No longer support PHP 5.6 or HHVM (EOL 2018-12-31)
+ ** No longer support PHP 7.1 (EOL 2019-12-01)
  ** Test with PHP 7.3 and 7.4
 
 * Version 2.6 released 2019-01-21

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,8 @@
 * Version 2.7 released 2020-02-??
  ** Default to just api.yubico.com (now load balanced)
  ** Retry transient errors
+ ** No longer support PHP 5.6 (EOL 2018-12-31)
+ ** Test with PHP 7.3 and 7.4
 
 * Version 2.6 released 2019-01-21
  ** Compat changes for PHP 7.

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+* Version 2.7 released 2020-02-??
+ ** Default to just api.yubico.com (now load balanced)
+ ** Retry transient errors
+
 * Version 2.6 released 2019-01-21
  ** Compat changes for PHP 7.
  ** Make https mandatory.

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,4 @@
-* Version 2.7 released 2020-02-??
+* Version 2.7 unreleased
  ** Default to just api.yubico.com (now load balanced)
  ** Retry transient errors
  ** No longer support PHP 5.6 or HHVM (EOL 2018-12-31)

--- a/README
+++ b/README
@@ -17,7 +17,7 @@ installed PEAR.  On Debian/Ubuntu systems:
 
 Install the component by invoking:
 
-  $ wget https://developers.yubico.com/php-yubico/Releases/Auth_Yubico-2.7.tgz
+  $ wget https://developers.yubico.com/php-yubico/Releases/Auth_Yubico-latest.tgz
   $ pear install Auth_Yubico-2.7.tgz
 
 === Usage ===

--- a/README
+++ b/README
@@ -17,8 +17,8 @@ installed PEAR.  On Debian/Ubuntu systems:
 
 Install the component by invoking:
 
-  $ wget https://developers.yubico.com/php-yubico/Releases/Auth_Yubico-2.6.tgz
-  $ pear install Auth_Yubico-2.6.tgz
+  $ wget https://developers.yubico.com/php-yubico/Releases/Auth_Yubico-2.7.tgz
+  $ pear install Auth_Yubico-2.7.tgz
 
 === Usage ===
 

--- a/Yubico.php
+++ b/Yubico.php
@@ -51,12 +51,6 @@ class Auth_Yubico
 	var $_key;
 
 	/**
-	 * URL part of validation server
-	 * @var string
-	 */
-	var $_url;
-
-	/**
 	 * List with URL part of validation servers
 	 * @var array
 	 */
@@ -107,14 +101,15 @@ class Auth_Yubico
 
 	/**
 	 * Specify to use a different URL part for verification.
-	 * The default is "api.yubico.com/wsapi/verify".
+	 * The default is "https://api.yubico.com/wsapi/2.0/verify".
 	 *
 	 * @param  string $url  New server URL part to use
 	 * @access public
+	 * @deprecated
 	 */
 	function setURLpart($url)
 	{
-		$this->_url = $url;
+	  $this->_url_list = array($url);
 	}
 
 	/**

--- a/Yubico.php
+++ b/Yubico.php
@@ -134,11 +134,7 @@ class Auth_Yubico
 	function getNextURLpart()
 	{
 	  if ($this->_url_list) $url_list=$this->_url_list;
-	  else $url_list=array('https://api.yubico.com/wsapi/2.0/verify',
-			       'https://api2.yubico.com/wsapi/2.0/verify',
-			       'https://api3.yubico.com/wsapi/2.0/verify',
-			       'https://api4.yubico.com/wsapi/2.0/verify',
-			       'https://api5.yubico.com/wsapi/2.0/verify');
+	  else $url_list=array('https://api.yubico.com/wsapi/2.0/verify');
 
 	  if ($this->_url_index>=count($url_list)) return false;
 	  else return $url_list[$this->_url_index++];

--- a/Yubico.php
+++ b/Yubico.php
@@ -453,10 +453,6 @@ class Auth_Yubico
 		    if ($valid) return true;
 		    return PEAR::raiseError($status);
 		  }
-		
-		curl_multi_remove_handle($mh, $info['handle']);
-		curl_close($info['handle']);
-		unset ($ch[(int)$info['handle']]);
 	      } else {
 		/* Some kind of error, but def. not a 200 response */
 		/* No status= in response body */
@@ -481,10 +477,11 @@ class Auth_Yubico
 		    $active = true;
 		  }
 		}
-		curl_multi_remove_handle($mh, $info['handle']);
-		curl_close($info['handle']);
-		unset ($ch[(int)$info['handle']]);
 	      }
+	      /* Done with this handle */
+	      curl_multi_remove_handle($mh, $info['handle']);
+	      curl_close($info['handle']);
+	      unset ($ch[(int)$info['handle']]);
 	    }
 	  } while ($active);
 

--- a/Yubico.php
+++ b/Yubico.php
@@ -5,7 +5,7 @@
    * @category    Auth
    * @package     Auth_Yubico
    * @author      Simon Josefsson <simon@yubico.com>, Olov Danielson <olov@yubico.com>
-   * @copyright   2007-2015 Yubico AB
+   * @copyright   2007-2020 Yubico AB
    * @license     https://opensource.org/licenses/bsd-license.php New BSD License
    * @version     2.0
    * @link        https://www.yubico.com/

--- a/Yubico.php
+++ b/Yubico.php
@@ -120,7 +120,7 @@ class Auth_Yubico
 	/**
 	 * Get next URL part from list to use for validation.
 	 *
-	 * @return mixed string with URL part of false if no more URLs in list
+	 * @return mixed string with URL part or false if no more URLs in list
 	 * @access public
 	 */
 	function getNextURLpart()

--- a/demo.php
+++ b/demo.php
@@ -40,7 +40,7 @@
    $wait_for_all = htmlspecialchars($_REQUEST["wait_for_all"]);
 
    if ($ask_url == 0 || !$url) {
-     $url = "api.yubico.com/wsapi/2.0/verify,api2.yubico.com/wsapi/2.0/verify,api3.yubico.com/wsapi/2.0/verify,api4.yubico.com/wsapi/2.0/verify,api5.yubico.com/wsapi/2.0/verify";
+     $url = "api.yubico.com/wsapi/2.0/verify";
     }
    if (!$id || !$otp) { $key = "oBVbNt7IZehZGR99rvq8d6RZ1DM="; }
    if (!$id) { $id = "1851"; }

--- a/package.xml
+++ b/package.xml
@@ -12,20 +12,20 @@ http://pear.php.net/dtd/package-2.0.xsd">
     <name>Simon Josefsson</name>
     <user>jas</user>
     <email>simon@yubico.com</email>
-    <active>yes</active>
+    <active>no</active>
   </lead>
-  <date>2008-10-07</date>
-  <time>19:22:42</time>
+  <date>2020-01-31</date>
+  <time>00:00:00</time>
   <version>
-    <release>2.6</release>
+    <release>2.7</release>
     <api>1.0</api>
   </version>
   <stability>
-    <release>alpha</release>
-    <api>alpha</api>
+    <release>beta</release>
+    <api>beta</api>
   </stability>
   <license uri="http://www.opensource.org/licenses/bsd-license.php">BSD</license>
-  <notes>This is the first release.
+  <notes>
   </notes>
   <contents>
     <dir name="/">

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,6 @@
 <phpunit
-  colors="true">
+    colors="true"
+    bootstrap="tests/bootstrap.php">
   <testsuite name="tests">
     <directory suffix="test.php">.</directory>
   </testsuite>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,19 @@
+<?php
+/* We need to redirect the webserver's stderr and stdout,
+ * otherwise exec() will wait for the webserver to close its
+ * stdout before returning in order to collect all its output.
+ */
+
+$command = '/usr/bin/env php -S localhost:3961 -t . >/dev/null 2>&1 & echo $!';
+$output = array();
+exec($command, $output);
+$webserver_pid = (int)$output[0];
+echo "webserver running as pid " . $webserver_pid . "\n";
+
+/* It appears that PHP kills off its children before we get to this point */
+/*
+register_shutdown_function(function() use ($webserver_pid) {
+    echo "killing webserver (pid " . $webserver_pid . ")\n";
+    exec('kill ' . $webserver_pid);
+});
+*/

--- a/tests/mock_verify.php
+++ b/tests/mock_verify.php
@@ -1,0 +1,5 @@
+<?php
+$parts = explode("/", $_SERVER['PATH_INFO']);
+http_response_code($parts[1]);
+echo $parts[2];
+?>

--- a/tests/yubico_test.php
+++ b/tests/yubico_test.php
@@ -6,7 +6,7 @@ require_once(__DIR__ . '/../Yubico.php');
 class YubicoTest extends \PHPUnit\Framework\TestCase {
   private $yubi;
 
-  public function setUp() {
+  public function setUp(): void {
     $this->yubi = new Auth_Yubico(27655, '9Tt8Gg51VG/dthDKgopt0n8IXVI=');
     error_reporting(E_WARNING);
   }
@@ -14,12 +14,52 @@ class YubicoTest extends \PHPUnit\Framework\TestCase {
   public function testVerify() {
     $otp = 'vvincrediblegfnchniugtdcbrleehenethrlbihdijv';
     $ret = $this->yubi->verify($otp);
-    $this->assertEquals($ret, 'REPLAYED_OTP');
+    $this->assertEquals('REPLAYED_OTP', $ret);
   }
 
   public function testBadOTP() {
     $otp = 'vvincrediblegfnchniugtdcbrleehenethrlbihdijc';
     $ret = $this->yubi->verify($otp);
-    $this->assertEquals($ret, 'NO_VALID_ANSWER');
+    $this->assertEquals('NO_VALID_ANSWER', $ret);
+  }
+}
+
+class RetryTest extends \PHPUnit\Framework\TestCase {
+  private $yubi;
+  private $webserver_url;
+  private $webserver_pid;
+    
+  public function setUp(): void {
+    $this->yubi = new Auth_Yubico(27655, '9Tt8Gg51VG/dthDKgopt0n8IXVI=');
+    $this->webserver_url = "http://localhost:3961";
+
+    $this->yubi->setURLpart($this->webserver_url . "/tests/mock_verify.php");
+	error_reporting(E_WARNING);
+  }
+
+  function setup_mock($response_code, $response_body) {
+	/* mock_verify will take requests like
+	 * /tests/mock_verify.php/500/status=NOPE?id=... and return a 500
+	 * with a body of status=NOPE
+	 */
+	$this->yubi->setURLpart($this->webserver_url . "/tests/mock_verify.php/" . $response_code . "/" . $response_body);
+  }
+    
+  public function testRetry500() {
+	$otp = 'vvincrediblegfnchniugtdcbrleehenethrlbihdijv';
+	$this->setup_mock(500, "status=OOPS");
+
+	$ret = $this->yubi->verify($otp);
+	$this->assertEquals('NO_VALID_ANSWER', $ret);
+	$this->assertEquals(3, $this->yubi->getRetries());
+  }
+
+  public function testRetry400() {
+	$otp = 'vvincrediblegfnchniugtdcbrleehenethrlbihdijv';
+	$this->setup_mock(400, "status=OK");
+
+	$ret = $this->yubi->verify($otp);
+	$this->assertEquals('NO_VALID_ANSWER', $ret);
+	$this->assertEquals(3, $this->yubi->getRetries());
   }
 }


### PR DESCRIPTION
The updated YubiCloud now does its own high availability and does not require parallel querying of several servers.

* Updates the defaults to just use api.yubico.com
* Adds retry logic, since we're not defaulting to 5 tries in parallel any more.
* A bit of drive-by cleanup
* Bump library version and prepare for new release